### PR TITLE
Look for config file between current working directory and home dir

### DIFF
--- a/README.md
+++ b/README.md
@@ -5,9 +5,11 @@ NBIoT-Go provides a Go client for the [REST API](https://api.nbiot.telenor.io) f
 
 ## Configuration
 
-The configuration file is located at `${HOME}/.telenor-nbiot`. The file is a simple
-list of key/value pairs. Additional values are ignored. Comments must start
-with a `#`:
+The configuration file is usually located at `${HOME}/.telenor-nbiot`,
+but the library will start at the current directory and scan each
+parent directory until it finds a config file. The file is a simple
+list of key/value pairs. Additional values are ignored. Comments must
+start with a `#`:
 
     #
     # This is the URL of the Telenor NB-IoT REST API. The default value is

--- a/client.go
+++ b/client.go
@@ -28,6 +28,15 @@ func New() (*Client, error) {
 	if err != nil {
 		return nil, err
 	}
+
+	if address == "" {
+		return nil, fmt.Errorf("No API address. Define %s environment variable or create config in %s", AddressEnvironmentVariable, ConfigFile)
+	}
+
+	if token == "" {
+		return nil, fmt.Errorf("No API token. Define %s environment variable or create config in %s", TokenEnvironmentVariable, ConfigFile)
+	}
+
 	return NewWithAddr(address, token)
 }
 
@@ -112,11 +121,7 @@ func newClientError(resp *http.Response) ClientError {
 	if err != nil {
 		return ClientError{resp.StatusCode, err.Error()}
 	}
-	msg := string(buf)
-	if resp.StatusCode == http.StatusUnauthorized {
-		msg = "The token you provided (or forget to provide) does not allow access to the requested resource."
-	}
-	return ClientError{resp.StatusCode, msg}
+	return ClientError{resp.StatusCode, string(buf)}
 }
 
 func (e ClientError) Error() string {

--- a/config.go
+++ b/config.go
@@ -71,9 +71,8 @@ func getFirstMatchingPath(filename string) string {
 	cwdParts := strings.Split(dir, string(os.PathSeparator))
 
 	for i := len(cwdParts); i >= 1; i-- {
-		s := strings.Join(cwdParts[:i], string(os.PathSeparator)) + "/"
+		s := strings.Join(cwdParts[:i], string(os.PathSeparator)) + string(os.PathSeparator)
 		f := filepath.Join(s, filename)
-
 		if _, err := os.Stat(f); os.IsNotExist(err) {
 			continue
 		}

--- a/config.go
+++ b/config.go
@@ -6,7 +6,6 @@ import (
 	"fmt"
 	"io/ioutil"
 	"os"
-	"os/user"
 	"path/filepath"
 	"strings"
 )
@@ -69,16 +68,10 @@ func getFirstMatchingPath(filename string) string {
 		return ""
 	}
 
-	usr, err := user.Current()
-	if err != nil {
-		return ""
-	}
-
-	numHomepathParts := len(strings.Split(usr.HomeDir, string(os.PathSeparator)))
 	cwdParts := strings.Split(dir, string(os.PathSeparator))
 
-	for i := len(cwdParts); i >= numHomepathParts; i-- {
-		s := strings.Join(cwdParts[:i], string(os.PathSeparator))
+	for i := len(cwdParts); i >= 1; i-- {
+		s := strings.Join(cwdParts[:i], string(os.PathSeparator)) + "/"
 		f := filepath.Join(s, filename)
 
 		if _, err := os.Stat(f); os.IsNotExist(err) {

--- a/config_test.go
+++ b/config_test.go
@@ -3,15 +3,26 @@ package nbiot
 import (
 	"io/ioutil"
 	"os"
+	"path/filepath"
 	"testing"
 )
 
+func TestFirstMatchingPath(t *testing.T) {
+	getFirstMatchingPath(".telenor-nbiot")
+}
+
 func TestFileDefaultConfig(t *testing.T) {
 
-	contents := "address=http://example.com\ntoken=sometoken"
+	cwd, err := os.Getwd()
+	if err != nil {
+		t.Fatal(err)
+	}
+	contents := "address=http://example.com\ntoken=sometoken\n"
 	tempFile := "telenor-nbiot.testconfig"
-	ioutil.WriteFile(getFullPath(tempFile), []byte(contents), 0666)
-	defer os.Remove(getFullPath(tempFile))
+	tempPath := filepath.Join(cwd, "telenor-nbiot.testconfig")
+
+	ioutil.WriteFile(tempPath, []byte(contents), 0666)
+	defer os.Remove(tempPath)
 
 	// unset the environment first to make sure it won't interfere with the
 	// file. It might contain settings that is in use so set it back to the
@@ -35,7 +46,7 @@ func TestFileDefaultConfig(t *testing.T) {
 	}
 
 	contents = "token=foobar\nsome=thing\nother=thing\n\nsome=thing=other\n\n"
-	ioutil.WriteFile(getFullPath(tempFile), []byte(contents), 0666)
+	ioutil.WriteFile(getFirstMatchingPath(tempFile), []byte(contents), 0666)
 	_, _, err = addressTokenFromConfig(tempFile)
 	if err == nil {
 		t.Fatal("expected error")


### PR DESCRIPTION
Look for config file between current working directory and home dir. The first match will be used.  Allows utilities to have local config files that override default config files in your home directory.

Added error messages for missing API address and API token since in actual use the error message ended up being the error message from Horde stating that the user is not authorized.