### PR TITLE
Added better error message to outputStream() function

### DIFF
--- a/outputstream.go
+++ b/outputstream.go
@@ -56,9 +56,9 @@ func (c *Client) outputStream(path string) (*OutputStream, error) {
 	header.Add("X-API-Token", c.token)
 
 	dialer := websocket.Dialer{}
-	ws, _, err := dialer.Dial(urlStr, header)
+	ws, resp, err := dialer.Dial(urlStr, header)
 	if err != nil {
-		return nil, err
+		return nil, fmt.Errorf("handshake failed with status %d", resp.StatusCode)
 	}
 
 	return &OutputStream{ws}, nil


### PR DESCRIPTION
The previous error message just says the handshake fails.  The new error message includes why.